### PR TITLE
Additional attributes for expressing more details on the image

### DIFF
--- a/pagecontent/schema/pagecontent.xsd
+++ b/pagecontent/schema/pagecontent.xsd
@@ -116,6 +116,11 @@
 		<attribute name="imageFilename" type="string" use="required"></attribute>
 		<attribute name="imageWidth" type="int" use="required"></attribute>
 		<attribute name="imageHeight" type="int" use="required"></attribute>
+		<attribute name="imageXResolution" type="int" use="required"></attribute>
+	        <attribute name="imageYResolution" type="int" use="required"></attribute>
+	        <attribute name="imageCompression" type="string" use="required"></attribute>
+	        <attribute name="imagePhotometricInterpretation" type="string" use="required"></attribute>
+	        <attribute name="imageResolutionUnit" type="string" use="required"></attribute>
 		<attribute name="custom" type="string">
 			<annotation>
 				<documentation>For generic use</documentation>

--- a/pagecontent/schema/pagecontent.xsd
+++ b/pagecontent/schema/pagecontent.xsd
@@ -116,11 +116,11 @@
 		<attribute name="imageFilename" type="string" use="required"></attribute>
 		<attribute name="imageWidth" type="int" use="required"></attribute>
 		<attribute name="imageHeight" type="int" use="required"></attribute>
-		<attribute name="imageXResolution" type="int" use="required"></attribute>
-	        <attribute name="imageYResolution" type="int" use="required"></attribute>
-	        <attribute name="imageCompression" type="string" use="required"></attribute>
-	        <attribute name="imagePhotometricInterpretation" type="string" use="required"></attribute>
-	        <attribute name="imageResolutionUnit" type="string" use="required"></attribute>
+		<attribute name="imageXResolution" type="int" use="optional"></attribute>
+	        <attribute name="imageYResolution" type="int" use="optional"></attribute>
+	        <attribute name="imageCompression" type="string" use="optional"></attribute>
+	        <attribute name="imagePhotometricInterpretation" type="string" use="optional"></attribute>
+	        <attribute name="imageResolutionUnit" type="string" use="optional"></attribute>
 		<attribute name="custom" type="string">
 			<annotation>
 				<documentation>For generic use</documentation>


### PR DESCRIPTION
We are currently setting up the OCR-D framework using PAGE XML. For the image pre-processing step, we'd like to propose a few additions to the image metadata header section. It would be great if they could be integrated into the “official” PAGE XML schema as well.