### PR TITLE
AlternativeImage for regions, lines, words and glyphs

### DIFF
--- a/pagecontent/documentation/changelog.txt
+++ b/pagecontent/documentation/changelog.txt
@@ -1,3 +1,7 @@
+2018-07-01
+
+*	AlternativeImage can be used on all regions, lines, words and glyphs.
+
 2015-09-01
 
 *	Bug fix: The constraint for the confidence value of OCRed text was not 

--- a/pagecontent/schema/pagecontent.xsd
+++ b/pagecontent/schema/pagecontent.xsd
@@ -450,6 +450,16 @@ Range: -179.999,180</documentation>
 	</complexType>
 	<complexType name="TextLineType">
 		<sequence>
+			<element name="AlternativeImage"
+				type="pc:AlternativeImageType" minOccurs="0"
+				maxOccurs="unbounded">
+				<annotation>
+					<documentation>
+						Alternative text line images (e.g.
+						black-and-white)
+					</documentation>
+				</annotation>
+			</element>
 			<element name="Coords" type="pc:CoordsType"></element>
 			<element name="Baseline" type="pc:BaselineType"
 				minOccurs="0">
@@ -536,6 +546,16 @@ Range: -179.999,180</documentation>
 	</complexType>
 	<complexType name="WordType">
 		<sequence>
+			<element name="AlternativeImage"
+				type="pc:AlternativeImageType" minOccurs="0"
+				maxOccurs="unbounded">
+				<annotation>
+					<documentation>
+						Alternative word images (e.g.
+						black-and-white)
+					</documentation>
+				</annotation>
+			</element>
 			<element name="Coords" type="pc:CoordsType"></element>
 			<element name="Glyph" type="pc:GlyphType" minOccurs="0"
 				maxOccurs="unbounded">
@@ -603,6 +623,16 @@ Range: -179.999,180</documentation>
 	</complexType>
 	<complexType name="GlyphType">
 		<sequence>
+			<element name="AlternativeImage"
+				type="pc:AlternativeImageType" minOccurs="0"
+				maxOccurs="unbounded">
+				<annotation>
+					<documentation>
+						Alternative glyph images (e.g.
+						black-and-white)
+					</documentation>
+				</annotation>
+			</element>
 			<element name="Coords" type="pc:CoordsType"></element>
 			<element name="Graphemes" type="pc:GraphemesType"
 				minOccurs="0" maxOccurs="1">
@@ -2129,6 +2159,16 @@ It does not contain pagenumber (if not part of running title), marginals, signat
 
     <complexType name="RegionType" abstract="true">
     	<sequence>
+			<element name="AlternativeImage"
+				type="pc:AlternativeImageType" minOccurs="0"
+				maxOccurs="unbounded">
+				<annotation>
+					<documentation>
+						Alternative region images (e.g.
+						black-and-white)
+					</documentation>
+				</annotation>
+			</element>
     		<element name="Coords" type="pc:CoordsType"></element>
     		<element name="UserDefined" type="pc:UserDefinedType"
     			minOccurs="0" maxOccurs="1">


### PR DESCRIPTION
For OCR-D we have the requirement to allow preprocessing not just on page level but on regions, text lines or words. For example, dewarping of individual text blocks or text lines.

In order to support these use cases, we extended the schema to allow `pc:AlternativeImage` as an optional first element within

* `RegionType`
* `TextLineType`
* `WordType`
* `GlyphType`

Would you consider to incorporate these extensions in the next PAGE release?

Thanks!

CC @wrznr @tboenig @cneud