### PR TITLE
Allow TextStyle on pc:Page, fix #7

### DIFF
--- a/pagecontent/schema/pagecontent.xsd
+++ b/pagecontent/schema/pagecontent.xsd
@@ -172,6 +172,9 @@
 			<element name="Relations" type="pc:RelationsType"
 				minOccurs="0">
 			</element>
+			<element name="TextStyle" type="pc:TextStyleType"
+				minOccurs="0" maxOccurs="1">
+			</element>
             <element name="UserDefined" type="pc:UserDefinedType" minOccurs="0" maxOccurs="1"></element>
             <element name="Labels" type="pc:LabelsType" minOccurs="0" maxOccurs="unbounded">
 				<annotation>


### PR DESCRIPTION
Allow `pc:TextStyle` as a child element of `pc:Page`.

@tboenig @chris1010010 