### PR TITLE
clarification on reading order sorting...

### DIFF
--- a/pagecontent/schema/pagecontent.xsd
+++ b/pagecontent/schema/pagecontent.xsd
@@ -1350,10 +1350,10 @@
 		<annotation>
 			<documentation>
 			Group containing index-ordered elements within an UnorderedGroup(Indexed)
-			Elements must be sorted contiguously according to their @index,
+			Elements must be sorted ascending monotonically according to their @index,
 			regardless of their type. (That is, the sequence of
 			OrderedGroupIndexed, UnorderedGroupIndexed or RegionRefIndexed elements
-			must start with index zero and each increase by one.)
+			must start with index zero and each increase by at least one.)
 			</documentation>
 		</annotation>
 		<sequence>
@@ -1466,10 +1466,10 @@
 		<annotation>
 			<documentation>
 			Group containing index-ordered elements within an OrderedGroup(Indexed).
-			Elements must be sorted contiguously according to their @index,
+			Elements must be sorted ascending monotonically according to their @index,
 			regardless of their type. (That is, the sequence of
 			OrderedGroupIndexed, UnorderedGroupIndexed or RegionRefIndexed elements
-			must start with index zero and each increase by one.)
+			must start with index zero and each increase by at least one.)
 			</documentation>
 		</annotation>
 		<sequence>


### PR DESCRIPTION
- require @index to be ascending monotonically
  (but still across types)

follow-up on https://github.com/PRImA-Research-Lab/prima-page-viewer/issues/15#issuecomment-623605873