### PR TITLE
pagecontent: allow region recursion for Map, too

### DIFF
--- a/pagecontent/schema/pagecontent.xsd
+++ b/pagecontent/schema/pagecontent.xsd
@@ -2349,6 +2349,7 @@
 				<element name="TableRegion" type="pc:TableRegionType"/>
 				<element name="ChartRegion" type="pc:ChartRegionType"/>
 				<element name="SeparatorRegion" type="pc:SeparatorRegionType"/>
+				<element name="MapRegion" type="pc:MapRegionType"/>
 				<element name="MathsRegion" type="pc:MathsRegionType"/>
 				<element name="ChemRegion" type="pc:ChemRegionType"/>
 				<element name="MusicRegion" type="pc:MusicRegionType"/>


### PR DESCRIPTION
Add `MapRegion` to the `xsd:choice` list within `RegionType` (as in `PageType`, and as all the other region types).

(I don't see a reason why this should be excluded – most likely just forgotten.)